### PR TITLE
Migration to remove Agency Table and house/agency reference

### DIFF
--- a/db/migrate/20220601090452_drop_agency_table.rb
+++ b/db/migrate/20220601090452_drop_agency_table.rb
@@ -1,0 +1,6 @@
+class DropAgencyTable < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :houses, :agency
+    drop_table :agencies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_31_100359) do
+ActiveRecord::Schema.define(version: 2022_06_01_090452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "agencies", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "phone_number"
-    t.string "address"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
 
   create_table "bookmarks", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -50,11 +41,9 @@ ActiveRecord::Schema.define(version: 2022_05_31_100359) do
     t.integer "price"
     t.integer "square_meters"
     t.integer "room_number"
-    t.bigint "agency_id", null: false
     t.bigint "district_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["agency_id"], name: "index_houses_on_agency_id"
     t.index ["district_id"], name: "index_houses_on_district_id"
   end
 
@@ -90,7 +79,6 @@ ActiveRecord::Schema.define(version: 2022_05_31_100359) do
   add_foreign_key "bookmarks", "houses"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "districts", "interests"
-  add_foreign_key "houses", "agencies"
   add_foreign_key "houses", "districts"
   add_foreign_key "interests", "types"
 end


### PR DESCRIPTION
Migration is working, uptaded schema no longer has Agency Table and Houses Table no longer has a reference to agency 